### PR TITLE
Update BLEDefines.h for Laird BL600

### DIFF
--- a/src/ios/BLEDefines.h
+++ b/src/ios/BLEDefines.h
@@ -25,7 +25,7 @@
 
 // Laird Virtual Serial Port (vSP) service for BL600 http://www.lairdtech.com/DownloadAsset.aspx?id=2147489885
 #define LAIRD_SERVICE_UUID                       "569a1101-b87f-490c-92cb-11ba5ea5167c"
-#define LAIRD_CHAR_TX_UUID                       "569a2001-b87f-490c-92cb-11ba5ea5167c"
-#define LAIRD_CHAR_RX_UUID                       "569a2000-b87f-490c-92cb-11ba5ea5167c"
+#define LAIRD_CHAR_TX_UUID                       "569a2000-b87f-490c-92cb-11ba5ea5167c"
+#define LAIRD_CHAR_RX_UUID                       "569a2001-b87f-490c-92cb-11ba5ea5167c"
 
 #define RBL_BLE_FRAMEWORK_VER                    0x0200


### PR DESCRIPTION
For this to work, the definitions for LAIRD_CHAR_TX_UUID and LAIRD_CHAR_RX_UUID need to be reversed.

I have it working nicely with the configuration in this version.
