### PR TITLE
Added listOnReach service for listing bluetooth devices nearby

### DIFF
--- a/src/android/org/apache/cordova/api/Dummy.java
+++ b/src/android/org/apache/cordova/api/Dummy.java
@@ -1,9 +1,0 @@
-package org.apache.cordova.api;
-
-// dummy class to ensure the org.apache.cordova.api package exists
-// this is required to support Cordova 2.9 and 3.0 with one code base
-// since I'm using wildcard imports to work around the renamed classes
-// import org.apache.cordova.*;
-// import org.apache.cordova.api.*;
-public class Dummy {
-}


### PR DESCRIPTION
I've added a `listOnReach` service for finding nearby Bluetooth devices.
The code was testes on my NexusOne (running CyanogenMod) and Nexus4 (Android Lolipop) without any issues.

OBS: For the future I'd want to add the capability to list LE devices, but still got to find how not to break on older devices.