### PR TITLE
Update bluetoothSerial.js

### DIFF
--- a/www/bluetoothSerial.js
+++ b/www/bluetoothSerial.js
@@ -113,7 +113,7 @@ module.exports = {
     },
 
     setDeviceDiscoveredListener: function (notify) {
-        if (typeof success != 'function')
+        if (typeof notify != 'function')
             throw 'BluetoothSerial.setDeviceDiscoveredListener: Callback not a function'
 
         cordova.exec(notify, null, "BluetoothSerial", "setDeviceDiscoveredListener", []);


### PR DESCRIPTION
setDeviceDiscoveredListener always throws a "Callback not a function" exception because the success variable doesn't exist. Changed success to notify to fix this.