### PR TITLE
Added support for Android 6.0 (API level 23).

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-bluetooth-serial"
-    version="0.4.5">
+    version="0.4.6">
 
     <name>Bluetooth Serial</name>
     <description>Bluetooth Serial Communication Plugin</description>
@@ -32,6 +32,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.BLUETOOTH" />
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
         </config-file>
 
     </platform>


### PR DESCRIPTION
I added runtime permission request according to the [Cordova Docs](https://cordova.apache.org/docs/en/6.x/guide/platforms/android/plugin.html#runtime-permissions-cordova-android-500). 
in API level 23 Android needs a third permission according to [Android 6.0 changes](http://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id).

The body of ``execute`` got wrapped in

    if(hasPermission(basePermissions))
    {
    [...]
    } else {
        cordova.requestPermissions(this, 0, basePermissions);
        callbackContext.error("Insufficient permissions.");
    }

and the action ``DISCOVER_UNPAIRED`` checks for the additional required permission.
So it'll only ask for the new needed permission when ``bluetoothSerial.discoverUnpaired(success, failure);`` is called.  

Bumped plugin version from 0.4.5 to 0.4.6.  
fixes #226, fixes #194 