### PR TITLE
Add hc02 Bluetooth BLE support

### DIFF
--- a/src/ios/BLE.m
+++ b/src/ios/BLE.m
@@ -30,6 +30,8 @@ CBUUID *adafruitServiceUUID;
 CBUUID *lairdServiceUUID;
 CBUUID *blueGigaServiceUUID;
 CBUUID *hm10ServiceUUID;
+CBUUID *hc02ServiceUUID;
+CBUUID *hc02AdvUUID;
 CBUUID *serialServiceUUID;
 CBUUID *readCharacteristicUUID;
 CBUUID *writeCharacteristicUUID;
@@ -214,7 +216,10 @@ CBUUID *writeCharacteristicUUID;
     lairdServiceUUID = [CBUUID UUIDWithString:@LAIRD_SERVICE_UUID];
     blueGigaServiceUUID = [CBUUID UUIDWithString:@BLUEGIGA_SERVICE_UUID];
     hm10ServiceUUID = [CBUUID UUIDWithString:@HM10_SERVICE_UUID];
-    NSArray *services = @[redBearLabsServiceUUID, adafruitServiceUUID, lairdServiceUUID, blueGigaServiceUUID, hm10ServiceUUID];
+    hc02ServiceUUID = [CBUUID UUIDWithString:@HC02_SERVICE_UUID];
+    hc02AdvUUID = [CBUUID UUIDWithString:@HC02_ADV_UUID];
+    NSArray *services = @[redBearLabsServiceUUID, adafruitServiceUUID, lairdServiceUUID, blueGigaServiceUUID, hm10ServiceUUID, 
+                        hc02AdvUUID];
     [self.CM scanForPeripheralsWithServices:services options: nil];
 #else
     [self.CM scanForPeripheralsWithServices:nil options:nil]; // Start scanning
@@ -556,6 +561,13 @@ static bool done = false;
                 serialServiceUUID = hm10ServiceUUID;
                 readCharacteristicUUID = [CBUUID UUIDWithString:@HM10_CHAR_TX_UUID];
                 writeCharacteristicUUID = [CBUUID UUIDWithString:@HM10_CHAR_RX_UUID];
+                break;
+            } else if ([service.UUID isEqual:hc02ServiceUUID]) {
+                NSLog(@"HC-02 Bluetooth");
+                NSLog(@"Set HC-02 read write UUID");
+                serialServiceUUID = hc02ServiceUUID;
+                readCharacteristicUUID = [CBUUID UUIDWithString:@HC02_CHAR_TX_UUID];
+                writeCharacteristicUUID = [CBUUID UUIDWithString:@HC02_CHAR_RX_UUID];
                 break;
             } else {
                 // ignore unknown services

--- a/src/ios/BLEDefines.h
+++ b/src/ios/BLEDefines.h
@@ -39,4 +39,11 @@
 #define HM10_CHAR_TX_UUID                       "ffe1"
 #define HM10_CHAR_RX_UUID                       "ffe1"
 
+// HC-02
+// http://www.hc01.com/productdetail?productid=20180314021
+#define HC02_SERVICE_UUID "49535343-FE7D-4AE5-8FA9-9FAFD205E455"
+#define HC02_CHAR_TX_UUID "49535343-1E4D-4BD9-BA61-23C647249616"
+#define HC02_CHAR_RX_UUID "49535343-8841-43F4-A8D4-ECBE34729BB3"
+#define HC02_ADV_UUID "18F0"
+
 #define RBL_BLE_FRAMEWORK_VER                    0x0200


### PR DESCRIPTION
 On branch add-hc02
 Changes to be committed:
	modified:   src/ios/BLE.m
	modified:   src/ios/BLEDefines.h

HC-02 is a  Bluetooth 2.0+4.0BLE module.  Compatible with hc-05/hc-06 and support iOS.
Please check: http://www.hc01.com/productdetail?productid=20180314021
It use "18F0" to be found when run scanForPeripheralsWithServices. 
Service UUID: "49535343-FE7D-4AE5-8FA9-9FAFD205E455"