### PR TITLE
Not trying to connect when Bluetooth is disabled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+.idea/

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -1,0 +1,15 @@
+ext.postBuildExtras = {
+    android {
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_7
+            targetCompatibility JavaVersion.VERSION_1_7
+        }
+        allprojects {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_1_7
+                targetCompatibility = JavaVersion.VERSION_1_7
+            }
+        }
+    }
+}
+

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,9 @@
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
         </config-file>
 
+	<!-- Enforces java 7 or higher: https://github.com/cvuser0/cordova-plugin-java7-->
+        <source-file src="build-extras.gradle" target-dir="../android" />
+
     </platform>
 
     <platform name="ios">

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -92,7 +92,7 @@ public class BluetoothSerial extends CordovaPlugin {
     @Override
     public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
 
-        LOG.d(TAG, "action = " + action);
+        //LOG.d(TAG, "action = " + action);
 
         if (bluetoothAdapter == null) {
             bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
@@ -110,14 +110,12 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(CONNECT)) {
 
-            boolean secure = true;
-            connect(args, secure, callbackContext);
+            connect(args, true, callbackContext);
 
         } else if (action.equals(CONNECT_INSECURE)) {
 
             // see Android docs about Insecure RFCOMM http://goo.gl/1mFjZY
-            boolean secure = false;
-            connect(args, secure, callbackContext);
+            connect(args, false, callbackContext);
 
         } else if (action.equals(DISCONNECT)) {
 
@@ -350,7 +348,7 @@ public class BluetoothSerial extends CordovaPlugin {
             callbackContext.sendPluginResult(result);
 
         } else {
-            callbackContext.error("Could not connect to " + macAddress);
+            callbackContext.error("Could not connect to " + macAddress + "(device not found/unreachable)");
         }
     }
 
@@ -400,7 +398,7 @@ public class BluetoothSerial extends CordovaPlugin {
                     //  Log.i(TAG, "Wrote: " + writeMessage);
                     break;
                 case MESSAGE_DEVICE_NAME:
-                    Log.i(TAG, msg.getData().getString(DEVICE_NAME));
+                    Log.i(TAG, "device name: " + msg.getData().getString(DEVICE_NAME));
                     break;
                 case MESSAGE_TOAST:
                     String message = msg.getData().getString(TOAST);

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -20,7 +20,7 @@ import android.util.Log;
  * connections with other devices. It has a thread that listens for
  * incoming connections, a thread for connecting with a device, and a
  * thread for performing data transmissions when connected.
- *
+ * <p>
  * This code was based on the Android SDK BluetoothChat Sample
  * $ANDROID_SDK/samples/android-17/BluetoothChat
  */
@@ -58,7 +58,8 @@ public class BluetoothSerialService {
 
     /**
      * Constructor. Prepares a new BluetoothSerial session.
-     * @param handler  A Handler to send messages back to the UI Activity
+     *
+     * @param handler A Handler to send messages back to the UI Activity
      */
     public BluetoothSerialService(Handler handler) {
         mAdapter = BluetoothAdapter.getDefaultAdapter();
@@ -68,7 +69,8 @@ public class BluetoothSerialService {
 
     /**
      * Set the current state of the chat connection
-     * @param state  An integer defining the current connection state
+     *
+     * @param state An integer defining the current connection state
      */
     private synchronized void setState(int state) {
         if (D) Log.d(TAG, "setState() " + mState + " -> " + state);
@@ -79,22 +81,30 @@ public class BluetoothSerialService {
     }
 
     /**
-     * Return the current connection state. */
+     * Return the current connection state.
+     */
     public synchronized int getState() {
         return mState;
     }
 
     /**
      * Start the chat service. Specifically start AcceptThread to begin a
-     * session in listening (server) mode. Called by the Activity onResume() */
+     * session in listening (server) mode. Called by the Activity onResume()
+     */
     public synchronized void start() {
         if (D) Log.d(TAG, "start");
 
         // Cancel any thread attempting to make a connection
-        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+        if (mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
+        }
 
         // Cancel any thread currently running a connection
-        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
 
         setState(STATE_NONE);
 
@@ -114,25 +124,30 @@ public class BluetoothSerialService {
 
     /**
      * Start the ConnectThread to initiate a connection to a remote device.
-     * @param device  The BluetoothDevice to connect
+     *
+     * @param device The BluetoothDevice to connect
      * @param secure Socket Security type - Secure (true) , Insecure (false)
      */
     public synchronized void connect(BluetoothDevice device, boolean secure) {
-        if (D) Log.d(TAG, "connect to: " + device);
+        if (D) Log.d(TAG, "Connecting to: " + device);
 
 
-        if (mAdapter == null || !mAdapter.isEnabled()){
+        if (mAdapter == null || !mAdapter.isEnabled()) {
             Log.e(TAG, "Bluetooth is disabled! Not connecting");
             return;
         }
 
         // Cancel any thread attempting to make a connection
-        if (mState == STATE_CONNECTING) {
-            if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+        if (mState == STATE_CONNECTING && mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
         }
 
         // Cancel any thread currently running a connection
-        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
 
         // Start the thread to connect with the given device
         mConnectThread = new ConnectThread(device, secure);
@@ -142,17 +157,24 @@ public class BluetoothSerialService {
 
     /**
      * Start the ConnectedThread to begin managing a Bluetooth connection
-     * @param socket  The BluetoothSocket on which the connection was made
-     * @param device  The BluetoothDevice that has been connected
+     *
+     * @param socket The BluetoothSocket on which the connection was made
+     * @param device The BluetoothDevice that has been connected
      */
     public synchronized void connected(BluetoothSocket socket, BluetoothDevice device, final String socketType) {
         if (D) Log.d(TAG, "connected, Socket Type:" + socketType);
 
         // Cancel the thread that completed the connection
-        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+        if (mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
+        }
 
         // Cancel any thread currently running a connection
-        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
 
         // Cancel the accept thread because we only want to connect to one device
         if (mSecureAcceptThread != null) {
@@ -208,6 +230,7 @@ public class BluetoothSerialService {
 
     /**
      * Write to the ConnectedThread in an unsynchronized manner
+     *
      * @param out The bytes to write
      * @see ConnectedThread#write(byte[])
      */
@@ -266,7 +289,7 @@ public class BluetoothSerialService {
 
         public AcceptThread(boolean secure) {
             BluetoothServerSocket tmp = null;
-            mSocketType = secure ? "Secure":"Insecure";
+            mSocketType = secure ? "Secure" : "Insecure";
 
             // Create a new listening server socket
             try {
@@ -376,7 +399,7 @@ public class BluetoothSerialService {
             // Make a connection to the BluetoothSocket
             try {
                 // This is a blocking call and will only return on a successful connection or an exception
-                Log.i(TAG,"Connecting to socket...");
+                Log.i(TAG, "Connecting to socket...");
                 mmSocket.connect();
             } catch (IOException | NullPointerException e) {
                 Log.e(TAG, e.toString());
@@ -384,8 +407,8 @@ public class BluetoothSerialService {
                 // Some 4.1 devices have problems, try an alternative way to connect
                 // See https://github.com/don/BluetoothSerial/issues/89
                 try {
-                    Log.i(TAG,"Trying fallback...");
-                    mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
+                    Log.i(TAG, "Trying fallback...");
+                    mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
                     mmSocket.connect();
                 } catch (Exception e2) {
                     Log.e(TAG, "Couldn't establish a Bluetooth connection.");
@@ -399,7 +422,7 @@ public class BluetoothSerialService {
                 }
             }
 
-            Log.i(TAG,"Successfully connected!");
+            Log.i(TAG, "Successfully connected!");
 
             // Reset the ConnectThread because we're done
             synchronized (BluetoothSerialService.this) {
@@ -481,7 +504,8 @@ public class BluetoothSerialService {
 
         /**
          * Write to the connected OutStream.
-         * @param buffer  The bytes to write
+         *
+         * @param buffer The bytes to write
          */
         public void write(byte[] buffer) {
             try {


### PR DESCRIPTION
Improved LogCat messages.
Caught NullPointerExceptions (occured when Bluetooth was disabled AND Android Location services was disabled)

Note: this change does require JAVA 7 or higher e.g. with this in build.gradle:
```
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_7
        targetCompatibility JavaVersion.VERSION_1_7
    }
```
The reason for this is catching multiple distinct Exceptions in one catch block.