### PR TITLE
Add IOS support for IMP006B & MTP-3B POS printers

### DIFF
--- a/src/ios/BLE.m
+++ b/src/ios/BLE.m
@@ -33,6 +33,7 @@ CBUUID *hm10ServiceUUID;
 CBUUID *hc02ServiceUUID;
 CBUUID *hc02AdvUUID;
 CBUUID *impServiceUUID;
+CBUUID *mtp3bServiceUUID;
 
 CBUUID *serialServiceUUID;
 CBUUID *readCharacteristicUUID;
@@ -221,8 +222,9 @@ CBUUID *writeCharacteristicUUID;
     hc02ServiceUUID = [CBUUID UUIDWithString:@HC02_SERVICE_UUID];
     hc02AdvUUID = [CBUUID UUIDWithString:@HC02_ADV_UUID];
     impServiceUUID = [CBUUID UUIDWithString:@IMP_SERVICE_UUID];
+    mtp3bServiceUUID = [CBUUID UUIDWithString:@MTP3_SERVICE_UUID];
     NSArray *services = @[redBearLabsServiceUUID, adafruitServiceUUID, lairdServiceUUID, blueGigaServiceUUID, hm10ServiceUUID, 
-                        hc02AdvUUID, impServiceUUID];
+                        hc02AdvUUID, impServiceUUID, mtp3bServiceUUID];
     [self.CM scanForPeripheralsWithServices:services options: nil];
 #else
     [self.CM scanForPeripheralsWithServices:nil options:nil]; // Start scanning
@@ -578,6 +580,12 @@ static bool done = false;
                 readCharacteristicUUID = [CBUUID UUIDWithString:@IMP_CHAR_TX_UUID];
                 writeCharacteristicUUID = [CBUUID UUIDWithString:@IMP_CHAR_RX_UUID];
                 break;
+             } else if ([service.UUID isEqual:mtp3bServiceUUID]) {
+                 NSLog(@"MTP-3B Bluetooth");
+                 serialServiceUUID = mtp3bServiceUUID;
+                 readCharacteristicUUID = [CBUUID UUIDWithString:@MTP3_CHAR_TX_UUID];
+                 writeCharacteristicUUID = [CBUUID UUIDWithString:@MTP3_CHAR_RX_UUID];
+                 break;
             } else {
                 // ignore unknown services
             }

--- a/src/ios/BLE.m
+++ b/src/ios/BLE.m
@@ -32,6 +32,8 @@ CBUUID *blueGigaServiceUUID;
 CBUUID *hm10ServiceUUID;
 CBUUID *hc02ServiceUUID;
 CBUUID *hc02AdvUUID;
+CBUUID *impServiceUUID;
+
 CBUUID *serialServiceUUID;
 CBUUID *readCharacteristicUUID;
 CBUUID *writeCharacteristicUUID;
@@ -218,8 +220,9 @@ CBUUID *writeCharacteristicUUID;
     hm10ServiceUUID = [CBUUID UUIDWithString:@HM10_SERVICE_UUID];
     hc02ServiceUUID = [CBUUID UUIDWithString:@HC02_SERVICE_UUID];
     hc02AdvUUID = [CBUUID UUIDWithString:@HC02_ADV_UUID];
+    impServiceUUID = [CBUUID UUIDWithString:@IMP_SERVICE_UUID];
     NSArray *services = @[redBearLabsServiceUUID, adafruitServiceUUID, lairdServiceUUID, blueGigaServiceUUID, hm10ServiceUUID, 
-                        hc02AdvUUID];
+                        hc02AdvUUID, impServiceUUID];
     [self.CM scanForPeripheralsWithServices:services options: nil];
 #else
     [self.CM scanForPeripheralsWithServices:nil options:nil]; // Start scanning
@@ -568,6 +571,12 @@ static bool done = false;
                 serialServiceUUID = hc02ServiceUUID;
                 readCharacteristicUUID = [CBUUID UUIDWithString:@HC02_CHAR_TX_UUID];
                 writeCharacteristicUUID = [CBUUID UUIDWithString:@HC02_CHAR_RX_UUID];
+                break;
+             } else if ([service.UUID isEqual:impServiceUUID]) {
+                NSLog(@"IMP006B Bluetooth");
+                serialServiceUUID = impServiceUUID;
+                readCharacteristicUUID = [CBUUID UUIDWithString:@IMP_CHAR_TX_UUID];
+                writeCharacteristicUUID = [CBUUID UUIDWithString:@IMP_CHAR_RX_UUID];
                 break;
             } else {
                 // ignore unknown services

--- a/src/ios/BLEDefines.h
+++ b/src/ios/BLEDefines.h
@@ -52,4 +52,10 @@
 #define IMP_CHAR_TX_UUID                       "2af0"
 #define IMP_CHAR_RX_UUID                       "2af1"
 
+// Bluetooth service for MTP-3B Thermal Pos Printer from China
+// http://www.xmjprt.com/bbx/2457738-2457759.html?id=52829&pid=2281589
+#define MTP3_SERVICE_UUID                       "E7810A71-73AE-499D-8C15-FAA9AEF0C3F2"
+#define MTP3_CHAR_TX_UUID                       "BEF8D6C9-9C21-4C9E-B632-BD58C1009F9F"
+#define MTP3_CHAR_RX_UUID                       "BEF8D6C9-9C21-4C9E-B632-BD58C1009F9F"
+
 #define RBL_BLE_FRAMEWORK_VER                    0x0200

--- a/src/ios/BLEDefines.h
+++ b/src/ios/BLEDefines.h
@@ -46,4 +46,10 @@
 #define HC02_CHAR_RX_UUID "49535343-8841-43F4-A8D4-ECBE34729BB3"
 #define HC02_ADV_UUID "18F0"
 
+// Bluetooth service for IMP006 Thermal Pos Printer from China
+// http://www.issyzonepos.com/IMP006-Bluetooth-Mobile-Thermal-Printer-For-Android-and-iOS-Mobile-Device_p100.html
+#define IMP_SERVICE_UUID                       "18f0"
+#define IMP_CHAR_TX_UUID                       "2af0"
+#define IMP_CHAR_RX_UUID                       "2af1"
+
 #define RBL_BLE_FRAMEWORK_VER                    0x0200


### PR DESCRIPTION
IMP006B is portable thermal printer made in China and widely available.
Device UUID is 35F03BAB-CCE4-ED12-71FF-8BAA7944738E
Tested and working with ESC/POS emulation.

More info on http://www.issyzonepos.com/IMP006-Bluetooth-Mobile-Thermal-Printer-For-Android-and-iOS-Mobile-Device_p100.html

