### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.BLUETOOTH" />
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
         </config-file>
 
     </platform>


### PR DESCRIPTION
For Android 10 and above, FINE_LOCATION access seems to be required to allow bluetooth scanning. See similar issue here: https://github.com/randdusing/cordova-plugin-bluetoothle/issues/579 .