### PR TITLE
Fixed Android 13, added "fineLocation" option

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022-11 Giuseppe Lanzi
+Copyright 2013-6 Don Coleman
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2013-6 Don Coleman
+Copyright 2022-11 Giuseppe Lanzi
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ If `enable` is called when Bluetooth is already enabled, the user will not promp
 
 Discover unpaired devices
 
-    bluetoothSerial.discoverUnpaired(success, failure);
+    bluetoothSerial.discoverUnpaired(fineLocation, success, failure);
 
 ### Description
 
@@ -572,6 +572,7 @@ Calling `connect` on an unpaired Bluetooth device should begin the Android pairi
 
 ### Parameters
 
+- __fineLocation__: True to enable fine geolocalization, set it as true only if you need to determine the physical position of the bluetooth devices. [optional]
 - __success__: Success callback function that is invoked with a list of unpaired devices.
 - __failure__: Error callback function, invoked when error occurs. [optional]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android Classic Bluetooth. iOS uses Bluetooth Low Energy.
 
 ## Supported Platforms
 
-* Android
+* Android with [Mini Thermal Printer POS-5809DD](https://www.amazon.com/Fesjoy-Portable-Wireless-Rechargeable-Plug%EF%BC%88100-240V%EF%BC%89/dp/B094QW8QCQ)
 * iOS with [RedBearLab](http://redbearlab.com) BLE hardware, [Adafruit Bluefruit LE](http://www.adafruit.com/products/1697), [Laird BL600](http://www.lairdtech.com/Products/Embedded-Wireless-Solutions/Bluetooth-Radio-Modules/BL600-Series/#.VBI7AS5dUzI), [BlueGiga](https://bluegiga.zendesk.com/entries/29185293--BGScript-spp-over-ble-AT-command-SPP-implementation-for-BLE), or [HC-02](http://www.hc01.com/productdetail?productid=20180314021)
 * Browser (Testing only. See [comments](https://github.com/don/BluetoothSerial/blob/master/src/browser/bluetoothSerial.js).)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Bluetooth Serial Plugin for PhoneGap
 
-This plugin enables serial communication over Bluetooth. It was written for communicating between Android or iOS and an Arduino.
+This plugin enables serial communication over Bluetooth. The original one was written for communicating between Android or iOS and an Arduino. This fork is meant to be able to connect and operate to a Bluetooth Printer
 
-Android and Windows Phone use Classic Bluetooth.  iOS uses Bluetooth Low Energy.
+Android Classic Bluetooth. iOS uses Bluetooth Low Energy.
 
 ## Supported Platforms
 
 * Android
 * iOS with [RedBearLab](http://redbearlab.com) BLE hardware, [Adafruit Bluefruit LE](http://www.adafruit.com/products/1697), [Laird BL600](http://www.lairdtech.com/Products/Embedded-Wireless-Solutions/Bluetooth-Radio-Modules/BL600-Series/#.VBI7AS5dUzI), [BlueGiga](https://bluegiga.zendesk.com/entries/29185293--BGScript-spp-over-ble-AT-command-SPP-implementation-for-BLE), or [HC-02](http://www.hc01.com/productdetail?productid=20180314021)
-* Windows Phone 8
 * Browser (Testing only. See [comments](https://github.com/don/BluetoothSerial/blob/master/src/browser/bluetoothSerial.js).)
 
 [Supporting other Bluetooth Low Energy hardware](#supporting-other-ble-hardware)
@@ -26,11 +25,11 @@ Install with Cordova cli
 
     $ cordova plugin add cordova-plugin-bluetooth-serial
 
-Note that this plugin's id changed from `com.megster.cordova.bluetoothserial` to `cordova-plugin-bluetooth-serial` as part of the migration from the [Cordova plugin repo](http://plugins.cordova.io/) to [npm](https://www.npmjs.com/).
+Note that this plugin's id changed from `com.megster.cordova.bluetoothserial` to `cordova-plugin-bluetooth-serial` and then to `cordova-plugin-bluetooth-serial-2` as part of the migration from the [Cordova plugin repo](http://plugins.cordova.io/) to [npm](https://www.npmjs.com/). Then it was change to be able to install the new version via npm.
 
 # Examples
 
-There are some [sample projects](https://github.com/don/BluetoothSerial/tree/master/examples) included with the plugin.
+There are some [sample projects](https://github.com/giuseppelanzi/BluetoothSerial/tree/master/examples) included with the plugin.
 
 # API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-bluetooth-serial",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Bluetooth Serial Communication Plugin",
   "main": "./www/bluetoothSerial.js",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,8 +30,8 @@
             target-dir="src/com/megster/cordova"/>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="18" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
             <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
             <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
             <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,9 +30,13 @@
             target-dir="src/com/megster/cordova"/>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-            <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+            <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
             <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+            <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+            <uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
+            <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
         </config-file>
 
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,13 +30,16 @@
             target-dir="src/com/megster/cordova"/>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="18" />
+            <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
             <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
             <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
             <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
             <uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
             <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
+            <!-- Needed only if your app uses Bluetooth scan results to derive physical location. -->
+            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
         </config-file>
 
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,9 +30,9 @@
             target-dir="src/com/megster/cordova"/>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.BLUETOOTH" />
-            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+            <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+            <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
         </config-file>
 
     </platform>

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -109,7 +109,7 @@ public class BluetoothSerial extends CordovaPlugin {
         boolean validAction = true;
         //
         if (action.equals(LIST)) {
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 if (cordova.hasPermission(BLUETOOTH_CONNECT) && cordova.hasPermission(BLUETOOTH_SCAN)) {
                     listBondedDevices(callbackContext);
                 }
@@ -195,7 +195,7 @@ public class BluetoothSerial extends CordovaPlugin {
             cordova.getActivity().startActivity(intent);
             callbackContext.success();
         } else if (action.equals(ENABLE)) {
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 if (cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT)) {
                     enableBluetoothCallback = callbackContext;
                     Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
@@ -214,11 +214,12 @@ public class BluetoothSerial extends CordovaPlugin {
                 cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
             }
         } else if (action.equals(DISCOVER_UNPAIRED)) {
-            // Android.Q and above needs different permissions
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            // Android.S and above needs different permissions
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 // I want to ask ACCESS_FINE_LOCATION only if I need it.
                 // Elseway it would be awkward asking an unneeded permission
-                boolean fineLocation = args.getBoolean(0) || false;
+                boolean fineLocation = false;
+                try {fineLocation = args.getBoolean(0) || false;} catch (Exception e1) {}
                 if (!fineLocation || (cordova.hasPermission(ACCESS_FINE_LOCATION) && fineLocation) && cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT)) {
                     discoverUnpairedDevices(callbackContext);
                 } else if (!cordova.hasPermission(ACCESS_FINE_LOCATION)) {
@@ -334,8 +335,8 @@ public class BluetoothSerial extends CordovaPlugin {
             }
         };
         //
-        // Android.Q and above require different permissions
-        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+        // Android.S and above require different permissions
+        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
             if (cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT)) {
                 Activity activity = cordova.getActivity();
                 activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -84,8 +84,10 @@ public class BluetoothSerial extends CordovaPlugin {
     private String delimiter;
     private static final int REQUEST_ENABLE_BLUETOOTH = 1;
 
-    // Android 23 requires user to explicitly grant permission for location to discover unpaired
-    private static final String ACCESS_COARSE_LOCATION = Manifest.permission.ACCESS_COARSE_LOCATION;
+    // Android 23 requires user to explicitly grant permission for bluetooth to discover unpaired
+    private static final String BLUETOOTH_SCAN = Manifest.permission.BLUETOOTH_SCAN;
+    private static final String BLUETOOTH_CONNECT = Manifest.permission.BLUETOOTH_CONNECT;
+    private static final String BLUETOOTH_ADVERTISE = Manifest.permission.BLUETOOTH_ADVERTISE;
     private static final int CHECK_PERMISSIONS_REQ_CODE = 2;
     private CallbackContext permissionCallback;
 
@@ -100,6 +102,19 @@ public class BluetoothSerial extends CordovaPlugin {
 
         if (bluetoothSerialService == null) {
             bluetoothSerialService = new BluetoothSerialService(mHandler);
+        }
+
+        if (!cordova.hasPermission(BLUETOOTH_SCAN)) {
+            LOG.d("RP", "ask permission: scan");
+            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, BLUETOOTH_SCAN);
+        }
+        if (!cordova.hasPermission(BLUETOOTH_ADVERTISE)) {
+            LOG.d("RP", "ask permission: advertise");
+            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, BLUETOOTH_ADVERTISE);
+        }
+        if (!cordova.hasPermission(BLUETOOTH_CONNECT)) {
+            LOG.d("RP", "ask permission: connect");
+            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, BLUETOOTH_CONNECT);
         }
 
         boolean validAction = true;
@@ -213,11 +228,11 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(DISCOVER_UNPAIRED)) {
 
-            if (cordova.hasPermission(ACCESS_COARSE_LOCATION)) {
+            if (cordova.hasPermission(BLUETOOTH_CONNECT)) {
                 discoverUnpairedDevices(callbackContext);
             } else {
                 permissionCallback = callbackContext;
-                cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, ACCESS_COARSE_LOCATION);
+                cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, BLUETOOTH_CONNECT);
             }
 
         } else if (action.equals(SET_DEVICE_DISCOVERED_LISTENER)) {
@@ -471,10 +486,10 @@ public class BluetoothSerial extends CordovaPlugin {
 
         for(int result:grantResults) {
             if(result == PackageManager.PERMISSION_DENIED) {
-                LOG.d(TAG, "User *rejected* location permission");
+                LOG.d(TAG, "User *rejected* bluetooth permission");
                 this.permissionCallback.sendPluginResult(new PluginResult(
                         PluginResult.Status.ERROR,
-                        "Location permission is required to discover unpaired devices.")
+                        "Bluetooth permission is required to discover unpaired devices.")
                     );
                 return;
             }
@@ -482,7 +497,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
         switch(requestCode) {
             case CHECK_PERMISSIONS_REQ_CODE:
-                LOG.d(TAG, "User granted location permission");
+                LOG.d(TAG, "User granted bluetooth permission");
                 discoverUnpairedDevices(permissionCallback);
                 break;
         }

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -218,7 +218,7 @@ public class BluetoothSerial extends CordovaPlugin {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                 // I want to ask ACCESS_FINE_LOCATION only if I need it.
                 // Elseway it would be awkward asking an unneeded permission
-                boolean fineLocation = false; // args.getBoolean(0);
+                boolean fineLocation = args.getBoolean(0) || false;
                 if (!fineLocation || (cordova.hasPermission(ACCESS_FINE_LOCATION) && fineLocation) && cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT)) {
                     discoverUnpairedDevices(callbackContext);
                 } else if (!cordova.hasPermission(ACCESS_FINE_LOCATION)) {

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -577,7 +577,7 @@ public class BluetoothSerial extends CordovaPlugin {
                 pluginResultMessage = "Fine location permission is granted.";
                 break;
             case CHECK_PERMISSIONS_REQ_CODE_ACCESS_COARSE_LOCATION:
-                logMessage = "User *rejected* coarse location permission";
+                logMessage = "User *granted* coarse location permission";
                 pluginResultMessage = "Coarse location permission is granted.";
                 break;
         }

--- a/www/bluetoothSerial.js
+++ b/www/bluetoothSerial.js
@@ -108,8 +108,8 @@ module.exports = {
         cordova.exec(success, failure, "BluetoothSerial", "enable", []);
     },
 
-    discoverUnpaired: function (success, failure) {
-        cordova.exec(success, failure, "BluetoothSerial", "discoverUnpaired", []);
+    discoverUnpaired: function (fineLocation, success, failure) {
+        cordova.exec(success, failure, "BluetoothSerial", "discoverUnpaired", [fineLocation]);
     },
 
     setDeviceDiscoveredListener: function (notify) {


### PR DESCRIPTION
I submit this PR in order to be able to fix the plugin for Android 12 and 13. 

In addition I added a _fineLocation_ option in the discover process. Some users reported that they find awkward to give location accesso in order to link to a bluetooth printer (sounds like a reasonable thing to say).

Hope it helps.