### PR TITLE
Add UUID to support MPT II Printers on iOS

### DIFF
--- a/src/ios/BLE.m
+++ b/src/ios/BLE.m
@@ -26,6 +26,7 @@ static int rssi = 0;
 
 // TODO should have a configurable list of services
 CBUUID *redBearLabsServiceUUID;
+CBUUID *mpt2ServiceUUID;
 CBUUID *adafruitServiceUUID;
 CBUUID *lairdServiceUUID;
 CBUUID *blueGigaServiceUUID;
@@ -537,6 +538,13 @@ static bool done = false;
                 serialServiceUUID = redBearLabsServiceUUID;
                 readCharacteristicUUID = [CBUUID UUIDWithString:@RBL_CHAR_TX_UUID];
                 writeCharacteristicUUID = [CBUUID UUIDWithString:@RBL_CHAR_RX_UUID];
+                break;
+            }
+            else if ([service.UUID isEqual:mpt2ServiceUUID]) {
+                NSLog(@"MPT II LE");
+                serialServiceUUID = mpt2ServiceUUID;
+                readCharacteristicUUID = [CBUUID UUIDWithString:@MPT2_CHAR_TX_UUID];
+                writeCharacteristicUUID = [CBUUID UUIDWithString:@MPT2_CHAR_RX_UUID];
                 break;
             } else if ([service.UUID isEqual:adafruitServiceUUID]) {
                 NSLog(@"Adafruit Bluefruit LE");

--- a/src/ios/BLEDefines.h
+++ b/src/ios/BLEDefines.h
@@ -11,6 +11,13 @@
  
  */
 
+// MPT II Service
+// For MPT II Printer
+#define MPT2_SERVICE_UUID                         "E7810A71-73AE-499D-8C15-FAA9AEF0C3F2"
+#define MPT2_CHAR_TX_UUID                         "0xBEF8D6C9-9C21-4C9E-B632-BD58C1009F9F"
+#define MPT2_CHAR_RX_UUID                         "0xBEF8D6C9-9C21-4C9E-B632-BD58C1009F9F"
+
+
 // BlueGiga Service
 #define BLUEGIGA_SERVICE_UUID                         "1D5688DE-866D-3AA4-EC46-A1BDDB37ECF6"
 #define BLUEGIGA_CHAR_TX_UUID                         "AF20fBAC-2518-4998-9AF7-AF42540731B3"
@@ -47,3 +54,4 @@
 #define HC02_ADV_UUID "18F0"
 
 #define RBL_BLE_FRAMEWORK_VER                    0x0200
+


### PR DESCRIPTION
- Add Service UUID
- Add characteristicUUID